### PR TITLE
Modernize pydantic-ai integration and add advanced examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
 dev:
 	uvicorn app.main:app --reload
 
-demo:	
+demo:
 	curl -X POST http://localhost:8000/generate \
 	  -H "Content-Type: application/json" \
-	  -d '{"description": "list all schemas"}'
+	  -d '{"description": "find all users emails"}'
+
+forecast:
+	curl -X POST http://localhost:8000/forecast \
+	  -H "Content-Type: application/json" \
+	  -d '{"query": "What will the weather be like in Beijing on Friday?"}'
+
+query-success:
+	curl -X POST http://localhost:8000/query \
+	  -H "Content-Type: application/json" \
+	  -d '{"query": "Select the names and countries of all capitals"}'
+
+query-sql-fail:
+	curl -X POST http://localhost:8000/query \
+	  -H "Content-Type: application/json" \
+	  -d '{"query": "Select all pets"}'
+
+query-router-fail:
+	curl -X POST http://localhost:8000/query \
+	  -H "Content-Type: application/json" \
+	  -d '{"query": "How do I fly from Amsterdam to Mexico City?"}'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,25 @@ uvicorn app.main:app --reload
 ```
 
 ## API
-- `POST /generate`
-  - Input: `{ "description": "something to organize" }`
-  - Output: `{ "title": "...", "priority": "..." }`
-```
+
+### `POST /generate`
+Generate a task with title and priority from a description.
+- Input: `{ "description": "something to organize" }`
+- Output: `{ "title": "...", "priority": "..." }`
+
+### `POST /forecast`
+Stream a weather forecast response.
+- Input: `{ "query": "weather question" }`
+- Output: Server-sent events stream
+
+### `POST /query`
+Demonstrates pydantic-ai output functions with router/SQL agent pattern.
+- Input: `{ "query": "natural language query" }`
+- Output: List of rows or error response
+
+Example queries:
+- `"Select the names and countries of all capitals"` - Returns capital cities
+- `"Select all pets"` - Returns SQL error (table not found)
+- `"How do I fly from Amsterdam to Mexico City?"` - Returns router error (no appropriate agent)
+
+Test with: `make query-success`, `make query-sql-fail`, or `make query-router-fail`

--- a/app/models.py
+++ b/app/models.py
@@ -5,3 +5,9 @@ class TaskInput(BaseModel):
 
 class TaskOutput(BaseModel):
     output: str
+
+class ForecastInput(BaseModel):
+    query: str
+
+class QueryInput(BaseModel):
+    query: str

--- a/app/router_agent.py
+++ b/app/router_agent.py
@@ -1,0 +1,89 @@
+import re
+
+from pydantic import BaseModel
+
+from pydantic_ai import Agent, ModelRetry, RunContext, UnexpectedModelBehavior
+
+
+class Row(BaseModel):
+    name: str
+    country: str
+
+
+tables = {
+    'capital_cities': [
+        Row(name='Amsterdam', country='Netherlands'),
+        Row(name='Mexico City', country='Mexico'),
+    ]
+}
+
+
+class SQLFailure(BaseModel):
+    """An unrecoverable failure. Only use this when you can't change the query to make it work."""
+
+    explanation: str
+
+
+def run_sql_query(query: str) -> list[Row]:
+    """Run a SQL query on the database."""
+
+    select_table = re.match(r'SELECT (.+) FROM (\w+)', query)
+    if select_table:
+        column_names = select_table.group(1)
+        if column_names != '*':
+            raise ModelRetry("Only 'SELECT *' is supported, you'll have to do column filtering manually.")
+
+        table_name = select_table.group(2)
+        if table_name not in tables:
+            raise ModelRetry(
+                f"Unknown table '{table_name}' in query '{query}'. Available tables: {', '.join(tables.keys())}."
+            )
+
+        return tables[table_name]
+
+    raise ModelRetry(f"Unsupported query: '{query}'.")
+
+
+sql_agent = Agent[None, list[Row] | SQLFailure](
+    'openai:gpt-5',
+    output_type=[run_sql_query, SQLFailure],
+    instructions='You are a SQL agent that can run SQL queries on a database.',
+)
+
+
+async def hand_off_to_sql_agent(ctx: RunContext, query: str) -> list[Row]:
+    """I take natural language queries, turn them into SQL, and run them on a database."""
+
+    # Drop the final message with the output tool call, as it shouldn't be passed on to the SQL agent
+    messages = ctx.messages[:-1]
+    try:
+        result = await sql_agent.run(query, message_history=messages)
+        output = result.output
+        if isinstance(output, SQLFailure):
+            raise ModelRetry(f'SQL agent failed: {output.explanation}')
+        return output
+    except UnexpectedModelBehavior as e:
+        # Bubble up potentially retryable errors to the router agent
+        if (cause := e.__cause__) and isinstance(cause, ModelRetry):
+            raise ModelRetry(f'SQL agent failed: {cause.message}') from e
+        else:
+            raise
+
+
+class RouterFailure(BaseModel):
+    """Use me when no appropriate agent is found or the used agent failed."""
+
+    explanation: str
+
+
+router_agent = Agent[None, list[Row] | RouterFailure](
+    'openai:gpt-5',
+    output_type=[hand_off_to_sql_agent, RouterFailure],
+    instructions='You are a router to other agents. Never try to solve a problem yourself, just pass it on.',
+)
+
+
+async def execute_query(query: str) -> list[Row] | RouterFailure:
+    """Execute a query using the router agent."""
+    result = await router_agent.run(query)
+    return result.output

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,9 +1,23 @@
 from fastapi import APIRouter
-from app.models import TaskInput, TaskOutput
+from app.models import TaskInput, TaskOutput, ForecastInput, QueryInput
 from app.services import generate_task
+from app.streaming import generate_forecast
+from app.router_agent import execute_query
+from fastapi.responses import StreamingResponse
 
 router = APIRouter()
 
 @router.post("/generate", response_model=TaskOutput)
 async def generate(data: TaskInput):
     return await generate_task(data.description)
+
+@router.post("/forecast")
+async def forecast(data: ForecastInput):
+    return StreamingResponse(
+        generate_forecast(data.query),
+        media_type="text/event-stream"
+    )
+
+@router.post("/query")
+async def query(data: QueryInput):
+    return await execute_query(data.query)

--- a/app/streaming.py
+++ b/app/streaming.py
@@ -1,0 +1,164 @@
+import asyncio
+from dataclasses import dataclass
+from datetime import date
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    FinalResultEvent,
+    FunctionToolCallEvent,
+    FunctionToolResultEvent,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPartDelta,
+    ToolCallPartDelta,
+)
+from pydantic_ai.tools import RunContext
+
+
+@dataclass
+class WeatherService:
+    async def get_forecast(self, location: str, forecast_date: date) -> str:
+        # In real code: call weather API, DB queries, etc.
+        return f'The forecast in {location} on {forecast_date} is 24°C and sunny.'
+
+    async def get_historic_weather(self, location: str, forecast_date: date) -> str:
+        # In real code: call a historical weather API or DB
+        return (
+            f'The weather in {location} on {forecast_date} was 18°C and partly cloudy.'
+        )
+
+
+weather_agent = Agent[WeatherService, str](
+    'openai:gpt-4o',
+    deps_type=WeatherService,
+    output_type=str,  # We'll produce a final answer as plain text
+    system_prompt='Providing a weather forecast at the locations the user provides.',
+)
+
+
+@weather_agent.tool
+async def weather_forecast(
+    ctx: RunContext[WeatherService],
+    location: str,
+    forecast_date: date,
+) -> str:
+    if forecast_date >= date.today():
+        return await ctx.deps.get_forecast(location, forecast_date)
+    else:
+        return await ctx.deps.get_historic_weather(location, forecast_date)
+
+
+output_messages: list[str] = []
+
+
+async def main():
+    user_prompt = 'What will the weather be like in Paris on Tuesday?'
+    # Begin a node-by-node, streaming iteration
+    async with weather_agent.iter(user_prompt, deps=WeatherService()) as run:
+        async for node in run:
+            if Agent.is_user_prompt_node(node):
+                # A user prompt node => The user has provided input
+                output_messages.append(f'=== UserPromptNode: {node.user_prompt} ===')
+            elif Agent.is_model_request_node(node):
+                # A model request node => We can stream tokens from the model's request
+                output_messages.append(
+                    '=== ModelRequestNode: streaming partial request tokens ==='
+                )
+                async with node.stream(run.ctx) as request_stream:
+                    async for event in request_stream:
+                        if isinstance(event, PartStartEvent):
+                            output_messages.append(
+                                f'[Request] Starting part {event.index}: {event.part!r}'
+                            )
+                        elif isinstance(event, PartDeltaEvent):
+                            if isinstance(event.delta, TextPartDelta):
+                                output_messages.append(
+                                    f'[Request] Part {event.index} text delta: {event.delta.content_delta!r}'
+                                )
+                            elif isinstance(event.delta, ToolCallPartDelta):
+                                output_messages.append(
+                                    f'[Request] Part {event.index} args_delta={event.delta.args_delta}'
+                                )
+                        elif isinstance(event, FinalResultEvent):
+                            output_messages.append(
+                                f'[Result] The model produced a final output (tool_name={event.tool_name})'
+                            )
+            elif Agent.is_call_tools_node(node):
+                # A handle-response node => The model returned some data, potentially calls a tool
+                output_messages.append(
+                    '=== CallToolsNode: streaming partial response & tool usage ==='
+                )
+                async with node.stream(run.ctx) as handle_stream:
+                    async for event in handle_stream:
+                        if isinstance(event, FunctionToolCallEvent):
+                            output_messages.append(
+                                f'[Tools] The LLM calls tool={event.part.tool_name!r} with args={event.part.args} (tool_call_id={event.part.tool_call_id!r})'
+                            )
+                        elif isinstance(event, FunctionToolResultEvent):
+                            output_messages.append(
+                                f'[Tools] Tool call {event.tool_call_id!r} returned => {event.result.content}'
+                            )
+            elif Agent.is_end_node(node):
+                # Once an End node is reached, the agent run is complete
+                output_messages.append(
+                    f'=== Final Agent Output: {node.data.output} ==='
+                )
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+
+    print(output_messages)
+    """
+    [
+        '=== UserPromptNode: What will the weather be like in Paris on Tuesday? ===',
+        '=== ModelRequestNode: streaming partial request tokens ===',
+        '[Request] Starting part 0: ToolCallPart(tool_name=\'weather_forecast\', args=\'{"location":"Pa\', tool_call_id=\'0001\', part_kind=\'tool-call\')',
+        '[Request] Part 0 args_delta=ris","forecast_',
+        '[Request] Part 0 args_delta=date":"2030-01-',
+        '[Request] Part 0 args_delta=01"}',
+        '=== CallToolsNode: streaming partial response & tool usage ===',
+        '[Tools] The LLM calls tool=\'weather_forecast\' with args={"location":"Paris","forecast_date":"2030-01-01"} (tool_call_id=\'0001\')',
+        "[Tools] Tool call '0001' returned => The forecast in Paris on 2030-01-01 is 24°C and sunny.",
+        '=== ModelRequestNode: streaming partial request tokens ===',
+        "[Request] Starting part 0: TextPart(content='It will be ', part_kind='text')",
+        '[Result] The model produced a final output (tool_name=None)',
+        "[Request] Part 0 text delta: 'warm and sunny '",
+        "[Request] Part 0 text delta: 'in Paris on '",
+        "[Request] Part 0 text delta: 'Tuesday.'",
+        '=== CallToolsNode: streaming partial response & tool usage ===',
+        '=== Final Agent Output: It will be warm and sunny in Paris on Tuesday. ===',
+    ]
+    """
+
+async def generate_forecast(query: str):
+    """
+    Generate a weather forecast based on the user's query.
+    Returns a generator that yields Server-Sent Events (SSE) formatted data.
+    """
+    async with weather_agent.iter(query, deps=WeatherService()) as run:
+        async for node in run:
+            if Agent.is_user_prompt_node(node):
+                # User prompt node - just acknowledge receipt
+                yield f"data: Processing query: {node.user_prompt}\n\n"
+            
+            elif Agent.is_model_request_node(node):
+                # Model request node - stream tokens from the model's request
+                async with node.stream(run.ctx) as request_stream:
+                    async for event in request_stream:
+                        if isinstance(event, FinalResultEvent):
+                            yield f"data: Generating forecast...\n\n"
+            
+            elif Agent.is_call_tools_node(node):
+                # Call tools node - stream tool usage
+                async with node.stream(run.ctx) as handle_stream:
+                    async for event in handle_stream:
+                        if isinstance(event, FunctionToolCallEvent):
+                            yield f"data: Looking up weather with {event.part.tool_name}\n\n"
+                        elif isinstance(event, FunctionToolResultEvent):
+                            yield f"data: Found weather data: {event.result.content}\n\n"
+            
+            elif Agent.is_end_node(node):
+                # End node - return the final result
+                yield f"data: {node.data.output}\n\n"
+                break


### PR DESCRIPTION
  Modernize pydantic-ai integration and add advanced examples

  Overview

  This PR updates the codebase to use the latest pydantic-ai v1.x APIs and adds
  comprehensive examples demonstrating advanced patterns including [output
  functions](https://ai.pydantic.dev/output/#output-functions), agent routing, and streaming.

  

  What Changed

  1. API Modernization (app/services.py)

  - Migrated from deprecated MCPServerHTTP to MCPServerStreamableHTTP
  - Updated parameter names: result_type → output_type, mcp_servers → toolsets
  - Updated result access: result.data → result.output
  - Removed deprecated run_mcp_servers() context manager

  2. Output Functions Example (app/router_agent.py - NEW)

  Demonstrates advanced pydantic-ai patterns:
  - Function-based outputs: Using functions as output types instead of just data
  models
  - Agent routing: Router agent that delegates to specialized sub-agents
  - Error handling: ModelRetry for recoverable errors, failure models for
  unrecoverable errors
  - Multi-agent coordination: SQL agent specialized for database queries with
  hand-off pattern

  Includes a sample database with capital cities and handles:
  - ✅ Successful queries
  - ❌ SQL errors (unknown tables)
  - ❌ Router failures (no appropriate agent)

  3. Streaming Example (app/streaming.py - NEW)

  Demonstrates streaming response patterns:
  - Node-by-node iteration with agent.iter()
  - Weather forecast agent with tool calling
  - Server-Sent Events (SSE) streaming for API clients
  - Proper streaming patterns: UserPromptNode, ModelRequestNode, CallToolsNode,
  EndNode handling
  - Correct result access: Uses node.data.output during iteration (fixes common
  streaming pitfall)

  4. API Integration (app/models.py, app/routes.py)

  - Added QueryInput and ForecastInput models
  - Added POST /query endpoint for router agent demonstration
  - Added POST /forecast endpoint for streaming weather forecasts
  - Converted endpoints to async/await pattern

  5. Documentation & Testing (Makefile, README.md)

  - Comprehensive API endpoint documentation
  - Added test commands:
    - make forecast - Test streaming weather endpoint
    - make query-success - Test successful SQL query
    - make query-sql-fail - Test table not found error
    - make query-router-fail - Test no appropriate agent error

  Testing

  # Start the server
  make dev

  # Test the new endpoints
  make forecast           # Streaming weather forecast
  make query-success      # Returns capital cities
  make query-sql-fail     # Returns SQL error
  make query-router-fail  # Returns router error

  Files Changed

  - app/services.py - Updated to current pydantic-ai APIs
  - app/router_agent.py - NEW: Output functions and router example
  - app/streaming.py - NEW: Streaming with agent.iter() example
  - app/models.py - Added input models for new endpoints
  - app/routes.py - Added /query and /forecast endpoints
  - Makefile - Added test commands
  - README.md - Added endpoint documentation

  Stats: 7 files changed, 334 insertions(+), 26 deletions(-)

  Benefits

  - ✅ Up-to-date APIs: Uses current pydantic-ai v1.x conventions
  - ✅ Production patterns: Demonstrates real-world agent patterns
  - ✅ Better DX: Test commands and documentation for easy exploration
  - ✅ Educational: Shows advanced features like output functions and streaming

  Notes

  - All changes are backward compatible with existing functionality
  - No breaking changes to existing /generate endpoint
  - New endpoints are independent demonstrations
  - Follows existing code style and project structure

  ---
  This PR serves as both a modernization effort and a comprehensive example suite
   for developers learning advanced pydantic-ai patterns.